### PR TITLE
Fix a bug with search bar when collapsed

### DIFF
--- a/src/components/Searchbar/Searchbar.tsx
+++ b/src/components/Searchbar/Searchbar.tsx
@@ -303,6 +303,7 @@ const Collapsed = styled(Typography)`
 
   &.enabled {
     top: 0;
+    display: none;
   }
 
   > * {


### PR DESCRIPTION
![Screenshot 2023-05-19 at 8 05 56 PM](https://github.com/acid-info/lpe-frontend/assets/41753422/38df4c4e-819e-449e-b8e5-eca9ae095f97)

How to reproduce :

1. Type something in the search bar
2. Click outside

How to fix : 

1. display: none for `&.enabled`
